### PR TITLE
Update fp.f90

### DIFF
--- a/src/fp.f90
+++ b/src/fp.f90
@@ -74,7 +74,7 @@ program SonicEncode
       read(10, "(a)", iostat=iRetCode) sBuffer
       if(iRetCode /= 0) then
         print *, 'error:: Empty input file'
-        stop
+        cycle
       end if
       iNumData = 0
       do
@@ -84,7 +84,7 @@ program SonicEncode
       end do
       if(iNumData <= 0) then
         print *, 'error:: No data in input file'
-        stop
+        cycle
       end if
       ! -1- Reserve workspace
       if(allocated(rvTimeStamp)) deallocate(rvTimeStamp)


### PR DESCRIPTION
Correction: previously, if a file was found wrong in input chain the processing would have stopped. Now, ill-firmed files are just skipped.